### PR TITLE
Add support for featured artworks

### DIFF
--- a/app/api/using_grape/artworks_endpoint.rb
+++ b/app/api/using_grape/artworks_endpoint.rb
@@ -4,7 +4,7 @@ module UsingGrape
 
     namespace :artworks do
       get do
-        Artwork.all.order(created_at: :desc)
+        Artwork.all.order(featured: :desc, created_at: :desc)
       end
 
       get ":id" do

--- a/app/api/using_grape/artworks_endpoint.rb
+++ b/app/api/using_grape/artworks_endpoint.rb
@@ -4,7 +4,7 @@ module UsingGrape
 
     namespace :artworks do
       get do
-        Artwork.all
+        Artwork.all.order(created_at: :desc)
       end
 
       get ":id" do

--- a/app/controllers/api/using_nothing/artworks_controller.rb
+++ b/app/controllers/api/using_nothing/artworks_controller.rb
@@ -2,7 +2,7 @@ module Api
   module UsingNothing
     class ArtworksController < ApplicationController
       def index
-        artworks = Artwork.all
+        artworks = Artwork.all.order(created_at: :desc)
         render json: artworks
       end
 

--- a/app/controllers/api/using_nothing/artworks_controller.rb
+++ b/app/controllers/api/using_nothing/artworks_controller.rb
@@ -2,7 +2,7 @@ module Api
   module UsingNothing
     class ArtworksController < ApplicationController
       def index
-        artworks = Artwork.all.order(created_at: :desc)
+        artworks = Artwork.all.order(featured: :desc, created_at: :desc)
         render json: artworks
       end
 

--- a/app/models/artwork.rb
+++ b/app/models/artwork.rb
@@ -1,6 +1,7 @@
 class Artwork < ApplicationRecord
   validates :amount_cents, presence: true
   validates :artist_name, presence: true
+  validates :featured, inclusion: {in: [true, false]}
   validates :medium, presence: true
   validates :title, presence: true
 end

--- a/db/migrate/20240305214626_add_featured_to_artworks.rb
+++ b/db/migrate/20240305214626_add_featured_to_artworks.rb
@@ -1,0 +1,5 @@
+class AddFeaturedToArtworks < ActiveRecord::Migration[7.1]
+  def change
+    add_column :artworks, :featured, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_05_151845) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_05_214626) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_05_151845) do
     t.integer "amount_cents"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "featured", default: false, null: false
   end
 
 end

--- a/spec/models/artwork_spec.rb
+++ b/spec/models/artwork_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe Artwork do
+  describe "validation" do
+    context "without required fields" do
+      it "is not valid" do
+        artwork = Artwork.new
+        expect(artwork).to_not be_valid
+      end
+    end
+
+    context "with required fields" do
+      it "is valid" do
+        artwork = Artwork.new(
+          amount_cents: 45_000,
+          artist_name: "Sally Sculptor",
+          medium: "Clay",
+          title: "Fancy cup"
+        )
+        expect(artwork).to be_valid
+      end
+    end
+  end
+
+  describe "defaults" do
+    it "sets featured to false by default" do
+      artwork = Artwork.new
+      expect(artwork.featured).to eq false
+    end
+  end
+end

--- a/spec/requests/using_grape/create_artwork_spec.rb
+++ b/spec/requests/using_grape/create_artwork_spec.rb
@@ -24,4 +24,19 @@ describe "POST /api/using_grape/artworks" do
       expect(response.parsed_body).to eq artwork.as_json
     end
   end
+
+  context "with bonus param" do
+    it "ignores that param" do
+      params = {
+        amount_cents: 100_000,
+        artist_name: "Sally Sculptor",
+        featured: true,
+        medium: "Clay",
+        title: "Fancy cup"
+      }
+      post "/api/using_grape/artworks", params: params
+      expect(response.status).to eq 201
+      expect(response.parsed_body["featured"]).to eq false
+    end
+  end
 end

--- a/spec/requests/using_grape/list_artworks_spec.rb
+++ b/spec/requests/using_grape/list_artworks_spec.rb
@@ -21,19 +21,36 @@ describe "GET /api/using_grape/artworks" do
 
   context "with a few artworks" do
     before do
-      FactoryBot.create(:artwork, title: "middle artwork", created_at: 2.days.ago)
-      FactoryBot.create(:artwork, title: "oldest artwork", created_at: 3.days.ago)
-      FactoryBot.create(:artwork, title: "newest artwork", created_at: 1.days.ago)
+      FactoryBot.create(
+        :artwork,
+        title: "middle artwork",
+        featured: false,
+        created_at: 2.days.ago
+      )
+
+      FactoryBot.create(
+        :artwork,
+        title: "oldest artwork",
+        featured: true,
+        created_at: 3.days.ago
+      )
+
+      FactoryBot.create(
+        :artwork,
+        title: "newest artwork",
+        featured: false,
+        created_at: 1.days.ago
+      )
     end
 
-    it "returns those artworks sorted by newest first" do
+    it "returns those artworks sorted by featured and then newest first" do
       get "/api/using_grape/artworks"
       expect(response.status).to eq 200
 
       expected_values = [
+        ["oldest artwork"],
         ["newest artwork"],
-        ["middle artwork"],
-        ["oldest artwork"]
+        ["middle artwork"]
       ]
 
       actual_values = response.parsed_body.map do |artwork|

--- a/spec/requests/using_grape/list_artworks_spec.rb
+++ b/spec/requests/using_grape/list_artworks_spec.rb
@@ -21,13 +21,26 @@ describe "GET /api/using_grape/artworks" do
 
   context "with a few artworks" do
     before do
-      FactoryBot.create_list(:artwork, 3)
+      FactoryBot.create(:artwork, title: "middle artwork", created_at: 2.days.ago)
+      FactoryBot.create(:artwork, title: "oldest artwork", created_at: 3.days.ago)
+      FactoryBot.create(:artwork, title: "newest artwork", created_at: 1.days.ago)
     end
 
-    it "returns those artworks" do
+    it "returns those artworks sorted by newest first" do
       get "/api/using_grape/artworks"
       expect(response.status).to eq 200
-      expect(response.parsed_body.count).to eq 3
+
+      expected_values = [
+        ["newest artwork"],
+        ["middle artwork"],
+        ["oldest artwork"]
+      ]
+
+      actual_values = response.parsed_body.map do |artwork|
+        artwork.values_at("title")
+      end
+
+      expect(actual_values).to eq expected_values
     end
   end
 end

--- a/spec/requests/using_grape/update_artwork_spec.rb
+++ b/spec/requests/using_grape/update_artwork_spec.rb
@@ -25,6 +25,17 @@ describe "PUT /api/using_grape/artworks/:id" do
     end
   end
 
+  context "with bonus param" do
+    it "ignores that param" do
+      params = {featured: true}
+
+      put "/api/using_grape/artworks/#{artwork.id}", params: params
+
+      expect(response.status).to eq 200
+      expect(response.parsed_body["featured"]).to eq false
+    end
+  end
+
   context "with full update" do
     it "returns a 200 and that updated artwork" do
       params = {

--- a/spec/requests/using_nothing/create_artwork_spec.rb
+++ b/spec/requests/using_nothing/create_artwork_spec.rb
@@ -24,4 +24,19 @@ describe "POST /api/using_nothing/artworks" do
       expect(response.parsed_body).to eq artwork.as_json
     end
   end
+
+  context "with bonus param" do
+    it "ignores that param" do
+      params = {
+        amount_cents: 100_000,
+        artist_name: "Sally Sculptor",
+        featured: true,
+        medium: "Clay",
+        title: "Fancy cup"
+      }
+      post "/api/using_nothing/artworks", params: params
+      expect(response.status).to eq 201
+      expect(response.parsed_body["featured"]).to eq false
+    end
+  end
 end

--- a/spec/requests/using_nothing/list_artworks_spec.rb
+++ b/spec/requests/using_nothing/list_artworks_spec.rb
@@ -21,19 +21,36 @@ describe "GET /api/using_nothing/artworks" do
 
   context "with a few artworks" do
     before do
-      FactoryBot.create(:artwork, title: "middle artwork", created_at: 2.days.ago)
-      FactoryBot.create(:artwork, title: "oldest artwork", created_at: 3.days.ago)
-      FactoryBot.create(:artwork, title: "newest artwork", created_at: 1.days.ago)
+      FactoryBot.create(
+        :artwork,
+        title: "middle artwork",
+        featured: false,
+        created_at: 2.days.ago
+      )
+
+      FactoryBot.create(
+        :artwork,
+        title: "oldest artwork",
+        featured: true,
+        created_at: 3.days.ago
+      )
+
+      FactoryBot.create(
+        :artwork,
+        title: "newest artwork",
+        featured: false,
+        created_at: 1.days.ago
+      )
     end
 
-    it "returns those artworks sorted by newest first" do
+    it "returns those artworks sorted by featured and then newest first" do
       get "/api/using_nothing/artworks"
       expect(response.status).to eq 200
 
       expected_values = [
+        ["oldest artwork"],
         ["newest artwork"],
-        ["middle artwork"],
-        ["oldest artwork"]
+        ["middle artwork"]
       ]
 
       actual_values = response.parsed_body.map do |artwork|

--- a/spec/requests/using_nothing/list_artworks_spec.rb
+++ b/spec/requests/using_nothing/list_artworks_spec.rb
@@ -21,13 +21,26 @@ describe "GET /api/using_nothing/artworks" do
 
   context "with a few artworks" do
     before do
-      FactoryBot.create_list(:artwork, 3)
+      FactoryBot.create(:artwork, title: "middle artwork", created_at: 2.days.ago)
+      FactoryBot.create(:artwork, title: "oldest artwork", created_at: 3.days.ago)
+      FactoryBot.create(:artwork, title: "newest artwork", created_at: 1.days.ago)
     end
 
-    it "returns those artworks" do
+    it "returns those artworks sorted by newest first" do
       get "/api/using_nothing/artworks"
       expect(response.status).to eq 200
-      expect(response.parsed_body.count).to eq 3
+
+      expected_values = [
+        ["newest artwork"],
+        ["middle artwork"],
+        ["oldest artwork"]
+      ]
+
+      actual_values = response.parsed_body.map do |artwork|
+        artwork.values_at("title")
+      end
+
+      expect(actual_values).to eq expected_values
     end
   end
 end

--- a/spec/requests/using_nothing/update_artwork_spec.rb
+++ b/spec/requests/using_nothing/update_artwork_spec.rb
@@ -25,6 +25,17 @@ describe "PUT /api/using_nothing/artworks/:id" do
     end
   end
 
+  context "with bonus param" do
+    it "ignores that param" do
+      params = {featured: true}
+
+      put "/api/using_nothing/artworks/#{artwork.id}", params: params
+
+      expect(response.status).to eq 200
+      expect(response.parsed_body["featured"]).to eq false
+    end
+  end
+
   context "with full update" do
     it "returns a 200 and that updated artwork" do
       params = {


### PR DESCRIPTION
This PR is meant to simulate what happens on software projects: things change and new features are added. In this case the idea is that we're going to add a boolean to `Artwork` called `featured` and use that to sort featured artworks to the top of our list endpoint. Our requirements include that only admins should be able to set this field and thus it should not be allowed to be set from the API.

In order to do this we start by adding a sort by newest first. Then we add the new property and then update the sort to prioritize featured artworks.

```
GET /api/using_grape/artworks

[
  { "title": "oldest artwork", "featured": true, "created_at": "2020-01-01 BLAH" },
  { "title": "newest artwork", "featured": false, "created_at": "2024-03-07 BLAH" },
  { "title": "middle artwork", "featured": false, "created_at": "2024-01-01 BLAH" }
]
```

Here `oldest artwork` comes first because it's featured and then the next two follow from that sorted by newest first.

The final two commits are adding tests that assert about whether this new field can be set via the API. The ones for Grape fail and demonstrate how it is weak on mass assignment protections by default.